### PR TITLE
VSCode拡張機能: README に拡張機能統計を追加して自動更新に組み込む

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,11 @@
 ![Download Stats](https://quickchart.io/chart?c=%7B%22type%22%3A%22line%22%2C%22data%22%3A%7B%22labels%22%3A%5B%222025-10-24%22%5D%2C%22datasets%22%3A%5B%7B%22label%22%3A%22pr-cannon%22%2C%22data%22%3A%5B366%5D%2C%22borderColor%22%3A%22%23FF6384%22%2C%22backgroundColor%22%3A%22transparent%22%2C%22tension%22%3A0.4%7D%5D%7D%2C%22options%22%3A%7B%22title%22%3A%7B%22display%22%3Atrue%2C%22text%22%3A%22npm%20Weekly%20Downloads%22%7D%2C%22scales%22%3A%7B%22yAxes%22%3A%5B%7B%22ticks%22%3A%7B%22beginAtZero%22%3Atrue%7D%7D%5D%7D%7D%7D&width=800&height=400)
 <!-- stats:end -->
 
+<!-- vscode-stats:start -->
+🚀 VSCode Extensions:
+- **Jules Extension**: 86 installs | ⭐ 4.5/5 | v1.0.4
+<!-- vscode-stats:end -->
+
 <!-- active-projects:start -->
 ## 🔨 Active Projects (Last 7 Days)
 
@@ -16,6 +21,6 @@ _Total: 318 commits across 6 projects_
 | **[pr-cannon](https://github.com/is0692vs/pr-cannon)** | **39** (12.3%) | 1d ago | 🔷 TypeScript | 0 |
 | **[otodoki2](https://github.com/is0692vs/otodoki2)** | **5** (1.6%) | 5d ago | 🔷 TypeScript | 0 |
 | **[Audicle](https://github.com/is0692vs/Audicle)** | **2** (0.6%) | 5d ago | 🟨 JavaScript | 0 |
-| **[ChronoClip](https://github.com/is0692vs/ChronoClip)** | **2** (0.6%) | 5d ago | 🟨 JavaScript | 0 |
+| **[ChronoClip](https://github.com/is0692vs/ChronoClip)** | **2** (0.6%) | 6d ago | 🟨 JavaScript | 0 |
 
 <!-- active-projects:end -->

--- a/config/extensions.ts
+++ b/config/extensions.ts
@@ -1,0 +1,4 @@
+// config/extensions.ts
+// VSCode拡張機能の監視リスト
+// 形式: publisher.extension-name
+export const vscodeExtensions = ["hirokimukai.jules-extension"];

--- a/modules/vscode-stats.ts
+++ b/modules/vscode-stats.ts
@@ -1,0 +1,105 @@
+import { vscodeExtensions } from "../config/extensions";
+
+interface ExtensionStats {
+  id: string;
+  name: string;
+  installs: number;
+  rating: number;
+  version: string;
+}
+
+async function fetchExtensionStats(
+  extensionId: string
+): Promise<ExtensionStats> {
+  const url =
+    "https://marketplace.visualstudio.com/_apis/public/gallery/extensionquery";
+
+  const body = {
+    filters: [
+      {
+        criteria: [
+          {
+            filterType: 7,
+            value: extensionId,
+          },
+        ],
+      },
+    ],
+    flags: 914,
+    assetTypes: ["Microsoft.VisualStudio.Code.WebResources|Markdown"],
+  };
+
+  const response = await fetch(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/json;api-version=3.0-preview.1",
+    },
+    body: JSON.stringify(body),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch stats for ${extensionId}`);
+  }
+
+  const data = await response.json();
+
+  if (
+    !data.results ||
+    !data.results[0] ||
+    !data.results[0].extensions ||
+    data.results[0].extensions.length === 0
+  ) {
+    throw new Error(`Extension not found: ${extensionId}`);
+  }
+
+  const extension = data.results[0].extensions[0];
+
+  // Extract stats - use statisticName instead of statisticId
+  const stats = extension.statistics || [];
+  const installs =
+    stats.find((s: { statisticName: string }) => s.statisticName === "install")
+      ?.value || 0;
+  const rating =
+    stats.find(
+      (s: { statisticName: string }) => s.statisticName === "weightedRating"
+    )?.value || 0;
+
+  return {
+    id: extensionId,
+    name: extension.displayName || extension.extensionName,
+    installs,
+    rating: parseFloat(parseFloat(rating).toFixed(1)),
+    version: extension.versions[0]?.version || "0.0.0",
+  };
+}
+
+export async function vscodeStats(): Promise<{
+  text: string;
+  data: ExtensionStats[];
+}> {
+  // 拡張機能リストが空の場合
+  if (vscodeExtensions.length === 0) {
+    return {
+      text: "🚀 VSCode Extensions:\n_No extensions configured_",
+      data: [],
+    };
+  }
+
+  const stats = await Promise.all(
+    vscodeExtensions.map((ext) => fetchExtensionStats(ext))
+  );
+
+  const text =
+    "🚀 VSCode Extensions:\n" +
+    stats
+      .map(
+        (s) =>
+          `- **${s.name}**: ${s.installs.toLocaleString()} installs | ⭐ ${
+            s.rating
+          }/5 | v${s.version}`
+      )
+      .join("\n");
+
+  return { text, data: stats };
+}

--- a/update-readme.ts
+++ b/update-readme.ts
@@ -2,6 +2,7 @@ import { readFileSync, writeFileSync, existsSync } from "fs";
 import { npmStats } from "./modules/npm-stats";
 import { generateChartUrl } from "./modules/chart";
 import { activeProjects } from "./modules/active-projects";
+import { vscodeStats } from "./modules/vscode-stats";
 
 interface StatsHistory {
   date: string;
@@ -50,6 +51,10 @@ async function main() {
     console.log("🔨 Fetching active projects...");
     const activeProjectsContent = await activeProjects();
 
+    // VSCode統計の処理
+    console.log("🚀 Fetching VSCode extension statistics...");
+    const { text: vscodeStatsText } = await vscodeStats();
+
     // READMEを更新
     console.log("📄 Reading README.md...");
     let readme = readFileSync("README.md", "utf-8");
@@ -68,10 +73,18 @@ async function main() {
       `<!-- active-projects:start -->\n${activeProjectsContent}\n<!-- active-projects:end -->`
     );
 
+    // vscode-stats部分を更新
+    readme = readme.replace(
+      /<!-- vscode-stats:start -->[\s\S]*<!-- vscode-stats:end -->/,
+      `<!-- vscode-stats:start -->\n${vscodeStatsText}\n<!-- vscode-stats:end -->`
+    );
+
     writeFileSync("README.md", readme);
     console.log("✅ README.md updated successfully!");
     console.log("\nUpdated stats:");
     console.log(statsContent);
+    console.log("\nUpdated VSCode stats:");
+    console.log(vscodeStatsText);
     console.log("\nUpdated active projects:");
     console.log(activeProjectsContent);
   } catch (error) {


### PR DESCRIPTION
- modules/vscode-stats.ts を追加し Marketplace からインストール数/評価/バージョンを取得
- config/extensions.ts を追加して監視する拡張機能一覧を管理
- update-readme.ts を更新して vscodeStats を呼び出し、README の vscode-stats セクションを更新・ログ出力
- README.md の vscode-stats ブロックを挿入および ChronoClip の最終プッシュ日を修正