### PR TITLE
🎵 Spotify表示を整理・簡素化、アクティブプロジェクトをカード化、トップ曲数を3に変更、README/VSCode統計を更新

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,81 +6,54 @@
 
 <!-- vscode-stats:start -->
 🚀 VSCode Extensions:
-- **Jules Extension**: 108 installs | ⭐ No ratings yet | v1.0.4
+- **Jules Extension**: 101 installs | ⭐ No ratings yet | v1.0.4
 
-![VSCode Extension Stats](https://quickchart.io/chart?c=%7B%22type%22%3A%22line%22%2C%22data%22%3A%7B%22labels%22%3A%5B%222025-10-24%22%2C%222025-10-25%22%2C%222025-10-26%22%5D%2C%22datasets%22%3A%5B%7B%22label%22%3A%22Jules%20Extension%22%2C%22data%22%3A%5B86%2C86%2C108%5D%2C%22borderColor%22%3A%22%239966FF%22%2C%22backgroundColor%22%3A%22transparent%22%2C%22tension%22%3A0.4%7D%5D%7D%2C%22options%22%3A%7B%22title%22%3A%7B%22display%22%3Atrue%2C%22text%22%3A%22VSCode%20Extension%20Installs%22%7D%2C%22scales%22%3A%7B%22yAxes%22%3A%5B%7B%22ticks%22%3A%7B%22beginAtZero%22%3Atrue%7D%7D%5D%7D%7D%7D&width=800&height=400)
+![VSCode Extension Stats](https://quickchart.io/chart?c=%7B%22type%22%3A%22line%22%2C%22data%22%3A%7B%22labels%22%3A%5B%222025-10-24%22%2C%222025-10-25%22%2C%222025-10-26%22%5D%2C%22datasets%22%3A%5B%7B%22label%22%3A%22Jules%20Extension%22%2C%22data%22%3A%5B86%2C86%2C101%5D%2C%22borderColor%22%3A%22%239966FF%22%2C%22backgroundColor%22%3A%22transparent%22%2C%22tension%22%3A0.4%7D%5D%7D%2C%22options%22%3A%7B%22title%22%3A%7B%22display%22%3Atrue%2C%22text%22%3A%22VSCode%20Extension%20Installs%22%7D%2C%22scales%22%3A%7B%22yAxes%22%3A%5B%7B%22ticks%22%3A%7B%22beginAtZero%22%3Atrue%7D%7D%5D%7D%7D%7D&width=800&height=400)
 <!-- vscode-stats:end -->
 
 <!-- commit-reflection:start -->
 直近3日間の活動サマリー:
-皆さん、お疲れ様です！🎉 直近3日間で130件のコミットがありました。Spotify API連携モジュールの追加とREADMEへの再生履歴表示機能の実装、設定UIの拡張など、素晴らしい進捗です！👏 特にREADMEの日本語対応と表記統一、お見事です！✨ この勢いで、今週も頑張っていきましょう！🚀
+お疲れ様です！🎉 直近3日間で130件のコミット、素晴らしいですね！✨ Spotify API連携機能の開発が進み、READMEへの再生履歴表示機能が追加されました。設定UIの拡張やドキュメントの整備も行われ、ますます使いやすくなっています。着々と進化していて感動です！引き続き、わくわくする開発を応援しています！🚀
 
 <!-- commit-reflection:end -->
 
 <!-- spotify:start -->
-## 🎵 Recently played (Last 3 Days)
+## 🎵 Recently played on Spotify (Last 3 Days)
 
 <table>
   <tr>
-    <td align="center" colspan="2">
-      <h3>🏆 #1 Most Played</h3>
+    <td align="center">
       <a href="https://open.spotify.com/track/1Z8JOVjvZNhwOdwOVqZPpI" target="_blank">
-        <img src="https://i.scdn.co/image/ab67616d0000b273fc5e4067581a0bf29e65afbb" alt="Good" width="200" />
+        <img src="https://i.scdn.co/image/ab67616d0000b273fc5e4067581a0bf29e65afbb" alt="Good" width="120" />
       </a>
       <br />
-      <strong>Good</strong>
+      <sub><strong>#1</strong></sub>
       <br />
-      CHANMINA
+      <sub>Good</sub>
       <br />
-      <sub>Naked</sub>
+      <sub>CHANMINA</sub>
     </td>
-  </tr>
-  <tr>
-    <td align="center" width="50%">
-      <strong>#2</strong>
-      <br />
+    <td align="center">
       <a href="https://open.spotify.com/track/3SS77BL8QoIWyoK0u7pDGQ" target="_blank">
-        <img src="https://i.scdn.co/image/ab67616d0000b273ae516ba0de5909fc9613a81b" alt="Like a Flower" width="150" />
+        <img src="https://i.scdn.co/image/ab67616d0000b273ae516ba0de5909fc9613a81b" alt="Like a Flower" width="120" />
       </a>
       <br />
-      <strong>Like a Flower</strong>
+      <sub><strong>#2</strong></sub>
       <br />
-      LANA
+      <sub>Like a Flower</sub>
+      <br />
+      <sub>LANA</sub>
     </td>
-    <td align="center" width="50%">
-      <strong>#3</strong>
-      <br />
+    <td align="center">
       <a href="https://open.spotify.com/track/5JTNhYqB0eG0ivgZcBviJ0" target="_blank">
-        <img src="https://i.scdn.co/image/ab67616d0000b2733d342336e7841b9beef14e1d" alt="ROSE" width="150" />
+        <img src="https://i.scdn.co/image/ab67616d0000b2733d342336e7841b9beef14e1d" alt="ROSE" width="120" />
       </a>
       <br />
-      <strong>ROSE</strong>
+      <sub><strong>#3</strong></sub>
       <br />
-      HANA
-    </td>
-  </tr>
-  <tr>
-    <td align="center" width="50%">
-      <strong>#4</strong>
+      <sub>ROSE</sub>
       <br />
-      <a href="https://open.spotify.com/track/6x6MPCHCBGyPDPXkoelyVN" target="_blank">
-        <img src="https://i.scdn.co/image/ab67616d0000b2739c7d4a442342da6cc2b7f8f4" alt="BAD LOVE" width="150" />
-      </a>
-      <br />
-      <strong>BAD LOVE</strong>
-      <br />
-      HANA
-    </td>
-    <td align="center" width="50%">
-      <strong>#5</strong>
-      <br />
-      <a href="https://open.spotify.com/track/5klNADgwB1K5j2quV0SCDL" target="_blank">
-        <img src="https://i.scdn.co/image/ab67616d0000b273fd30f0feb5e182d5c85210c7" alt="Blue Jeans" width="150" />
-      </a>
-      <br />
-      <strong>Blue Jeans</strong>
-      <br />
-      HANA
+      <sub>HANA</sub>
     </td>
   </tr>
 </table>
@@ -89,12 +62,44 @@
 <!-- active-projects:start -->
 ## 🔨 Active Projects (Last 3 Days)
 
-_Total: 84 commits across 3 projects_
+_Total: 82 commits across 3 projects_
 
-| 🚀 Project | 📊 Commits | ⏱️ Last Push | 💻 Language | ⭐ Stars |
-|:-----------|:-----------|:-------------|:------------|:--------:|
-| **[code-mantra](https://github.com/is0692vs/code-mantra)** | **38** (45.2%) | 2h ago | 🔷 TypeScript | 0 |
-| **[pr-cannon](https://github.com/is0692vs/pr-cannon)** | **38** (45.2%) | 18h ago | 🔷 TypeScript | 0 |
-| **[jules-extension](https://github.com/is0692vs/jules-extension)** | **8** (9.5%) | 1d ago | 🔷 TypeScript | 1 |
+<table>
+  <tr>
+    <td align="center" width="33%">
+      <a href="https://github.com/is0692vs/code-mantra" target="_blank">
+        <img src="https://opengraph.githubassets.com/1/is0692vs/code-mantra" alt="code-mantra" width="100%" />
+      </a>
+      <br />
+      <sub><strong><a href="https://github.com/is0692vs/code-mantra" target="_blank">code-mantra</a></strong></sub>
+      <br />
+      <sub>📊 38 commits (46.3%)</sub>
+      <br />
+      <sub>🔷 TypeScript </sub>
+    </td>
+    <td align="center" width="33%">
+      <a href="https://github.com/is0692vs/pr-cannon" target="_blank">
+        <img src="https://opengraph.githubassets.com/1/is0692vs/pr-cannon" alt="pr-cannon" width="100%" />
+      </a>
+      <br />
+      <sub><strong><a href="https://github.com/is0692vs/pr-cannon" target="_blank">pr-cannon</a></strong></sub>
+      <br />
+      <sub>📊 36 commits (43.9%)</sub>
+      <br />
+      <sub>🔷 TypeScript </sub>
+    </td>
+    <td align="center" width="33%">
+      <a href="https://github.com/is0692vs/jules-extension" target="_blank">
+        <img src="https://opengraph.githubassets.com/1/is0692vs/jules-extension" alt="jules-extension" width="100%" />
+      </a>
+      <br />
+      <sub><strong><a href="https://github.com/is0692vs/jules-extension" target="_blank">jules-extension</a></strong></sub>
+      <br />
+      <sub>📊 8 commits (9.8%)</sub>
+      <br />
+      <sub>🔷 TypeScript ⭐ 1</sub>
+    </td>
+  </tr>
+</table>
 
 <!-- active-projects:end -->

--- a/config/spotify.ts
+++ b/config/spotify.ts
@@ -1,7 +1,7 @@
 /**
  * Spotify TOP曲の表示設定
  */
-export const SPOTIFY_TOP_TRACKS_LIMIT = 5;
+export const SPOTIFY_TOP_TRACKS_LIMIT = 3;
 
 export const spotifyConfig = {
     clientId: process.env.SPOTIFY_CLIENT_ID || process.env.YOUR_CLIENT_ID || '',

--- a/data/vscode-stats-history.json
+++ b/data/vscode-stats-history.json
@@ -14,7 +14,7 @@
   {
     "date": "2025-10-26",
     "extensions": {
-      "Jules Extension": 108
+      "Jules Extension": 101
     }
   }
 ]

--- a/modules/spotify-top-tracks.ts
+++ b/modules/spotify-top-tracks.ts
@@ -103,71 +103,37 @@ export async function getTopTracks(): Promise<string> {
 
         // Markdown形式に整形
         if (!data.items || data.items.length === 0) {
-            return `🎵 Recently played (Last ${DAYS_RANGE} Days):\n\n_No tracks found_`;
+            return `🎵 Recently played on Spotify (Last ${DAYS_RANGE} Days):\n\n_No tracks found_`;
         }
 
         // ヘッダー
-        let markdown = `## 🎵 Recently played (Last ${DAYS_RANGE} Days)\n\n`;
+        let markdown = `## 🎵 Recently played on Spotify (Last ${DAYS_RANGE} Days)\n\n`;
 
-        // HTMLテーブルでSpotify Embedを使った楽曲カードを生成
+        // 横並びレイアウト - 1行のテーブルで実装
         markdown += '<table>\n';
+        markdown += '  <tr>\n';
 
         data.items.forEach((track, index) => {
-            const trackId = track.id;
             const trackName = track.name;
             const artistName = track.artists.map(a => a.name).join(", ");
-            const albumName = track.album.name;
             const albumArt = track.album.images[0]?.url || "";
             const spotifyUrl = track.external_urls.spotify;
 
-            // 2列レイアウト（トップは1列、残り4曲は2列x2行）
-            if (index === 0) {
-                // 1位は大きく表示
-                markdown += '  <tr>\n';
-                markdown += '    <td align="center" colspan="2">\n';
-                markdown += `      <h3>🏆 #1 Most Played</h3>\n`;
-                markdown += `      <a href="${spotifyUrl}" target="_blank">\n`;
-                markdown += `        <img src="${albumArt}" alt="${trackName}" width="200" />\n`;
-                markdown += `      </a>\n`;
-                markdown += `      <br />\n`;
-                markdown += `      <strong>${trackName}</strong>\n`;
-                markdown += `      <br />\n`;
-                markdown += `      ${artistName}\n`;
-                markdown += `      <br />\n`;
-                markdown += `      <sub>${albumName}</sub>\n`;
-                markdown += '    </td>\n';
-                markdown += '  </tr>\n';
-            } else if (index % 2 === 1) {
-                // 2位以降は2列レイアウト（奇数インデックスで新しい行を開始）
-                markdown += '  <tr>\n';
-                markdown += '    <td align="center" width="50%">\n';
-                markdown += `      <strong>#${index + 1}</strong>\n`;
-                markdown += `      <br />\n`;
-                markdown += `      <a href="${spotifyUrl}" target="_blank">\n`;
-                markdown += `        <img src="${albumArt}" alt="${trackName}" width="150" />\n`;
-                markdown += `      </a>\n`;
-                markdown += `      <br />\n`;
-                markdown += `      <strong>${trackName}</strong>\n`;
-                markdown += `      <br />\n`;
-                markdown += `      ${artistName}\n`;
-                markdown += '    </td>\n';
-            } else {
-                // 偶数インデックスで行を閉じる
-                markdown += '    <td align="center" width="50%">\n';
-                markdown += `      <strong>#${index + 1}</strong>\n`;
-                markdown += `      <br />\n`;
-                markdown += `      <a href="${spotifyUrl}" target="_blank">\n`;
-                markdown += `        <img src="${albumArt}" alt="${trackName}" width="150" />\n`;
-                markdown += `      </a>\n`;
-                markdown += `      <br />\n`;
-                markdown += `      <strong>${trackName}</strong>\n`;
-                markdown += `      <br />\n`;
-                markdown += `      ${artistName}\n`;
-                markdown += '    </td>\n';
-                markdown += '  </tr>\n';
-            }
+            // 各曲を横並びに配置
+            markdown += '    <td align="center">\n';
+            markdown += `      <a href="${spotifyUrl}" target="_blank">\n`;
+            markdown += `        <img src="${albumArt}" alt="${trackName}" width="120" />\n`;
+            markdown += `      </a>\n`;
+            markdown += `      <br />\n`;
+            markdown += `      <sub><strong>#${index + 1}</strong></sub>\n`;
+            markdown += `      <br />\n`;
+            markdown += `      <sub>${trackName}</sub>\n`;
+            markdown += `      <br />\n`;
+            markdown += `      <sub>${artistName}</sub>\n`;
+            markdown += '    </td>\n';
         });
 
+        markdown += '  </tr>\n';
         markdown += '</table>\n';
 
         return markdown.trim();
@@ -177,16 +143,16 @@ export async function getTopTracks(): Promise<string> {
         // エラーメッセージを返す
         if (error instanceof Error) {
             if (error.message.includes("credentials are not configured")) {
-                return `🎵 Recently played (Last ${DAYS_RANGE} Days):\n\n_Spotify credentials not configured_`;
+                return `🎵 Recently played on Spotify (Last ${DAYS_RANGE} Days):\n\n_Spotify credentials not configured_`;
             }
             if (error.message.includes("401")) {
-                return `🎵 Recently played (Last ${DAYS_RANGE} Days):\n\n_Authentication error: Please check Spotify credentials_`;
+                return `🎵 Recently played on Spotify (Last ${DAYS_RANGE} Days):\n\n_Authentication error: Please check Spotify credentials_`;
             }
             if (error.message.includes("429")) {
-                return `🎵 Recently played (Last ${DAYS_RANGE} Days):\n\n_API rate limit exceeded. Please try again later._`;
+                return `🎵 Recently played on Spotify (Last ${DAYS_RANGE} Days):\n\n_API rate limit exceeded. Please try again later._`;
             }
         }
 
-        return `🎵 Recently played (Last ${DAYS_RANGE} Days):\n\n_Error fetching tracks. Please try again later._`;
+        return `🎵 Recently played on Spotify (Last ${DAYS_RANGE} Days):\n\n_Error fetching tracks. Please try again later._`;
     }
 }


### PR DESCRIPTION
- modules/spotify-top-tracks.ts: 表示レイアウトを簡素化（横並びのHTMLテーブルに統一）、文言を "Recently played on Spotify" に統一、エラーメッセージも合わせて更新
- modules/active-projects.ts: テーブル形式からSpotify風カードレイアウトにリファクタ（上位3プロジェクトのみ表示）、不要だった補助関数(getRelativeTime / getCommitBar / generateAnimatedCircleChart 等)を削除、出力フォーマットをMarkdown+HTMLテーブルに変更
- config/spotify.ts: SPOTIFY_TOP_TRACKS_LIMIT を 5 → 3 に変更
- data/vscode-stats-history.json / README.md: VSCode拡張のインストール数など統計値を更新、README内のSpotifyセクション表記・レイアウト調整とコミット振り返り文言の微修正