### PR TITLE
🔁 repositoryUrl を relatedUrl にリネーム

### DIFF
--- a/config/extensions.ts
+++ b/config/extensions.ts
@@ -2,16 +2,16 @@
 // VSCode拡張機能の監視リスト
 export interface VscodeExtensionConfig {
     id: string; // publisher.extension-name 形式
-    repositoryUrl?: string;
+    relatedUrl?: string;
 }
 
 export const vscodeExtensions: VscodeExtensionConfig[] = [
     {
         id: "hirokimukai.jules-extension",
-        repositoryUrl: "https://github.com/is0692vs/jules-extension",
+        relatedUrl: "https://github.com/is0692vs/jules-extension",
     },
     {
         id: "hirokimukai.code-mantra",
-        repositoryUrl: "https://github.com/is0692vs/code-mantra",
+        relatedUrl: "https://github.com/is0692vs/code-mantra",
     },
 ];

--- a/config/packages.ts
+++ b/config/packages.ts
@@ -1,12 +1,12 @@
 // config/packages.ts
 export interface NpmPackageConfig {
     name: string;
-    repositoryUrl?: string;
+    relatedUrl?: string;
 }
 
 export const npmPackages: NpmPackageConfig[] = [
     {
         name: "pr-cannon",
-        repositoryUrl: "https://github.com/is0692vs/pr-cannon",
+        relatedUrl: "https://github.com/is0692vs/pr-cannon",
     },
 ];

--- a/modules/npm-stats.ts
+++ b/modules/npm-stats.ts
@@ -3,7 +3,7 @@ import { npmPackages, type NpmPackageConfig } from "../config/packages";
 interface NpmStats {
   package: string;
   downloads: number;
-  repositoryUrl?: string;
+  relatedUrl?: string;
 }
 
 async function fetchNpmStats(config: NpmPackageConfig): Promise<NpmStats> {
@@ -19,7 +19,7 @@ async function fetchNpmStats(config: NpmPackageConfig): Promise<NpmStats> {
   return {
     package: config.name,
     downloads: data.downloads,
-    repositoryUrl: config.repositoryUrl,
+    relatedUrl: config.relatedUrl,
   };
 }
 
@@ -28,8 +28,8 @@ export async function npmStats(): Promise<{ text: string; data: NpmStats[] }> {
 
   const text = stats
     .map((s) => {
-      const packageName = s.repositoryUrl
-        ? `[${s.package}](${s.repositoryUrl})`
+      const packageName = s.relatedUrl
+        ? `[${s.package}](${s.relatedUrl})`
         : s.package;
       return `📦 **${packageName}**: ${s.downloads.toLocaleString()} downloads/week`;
     })

--- a/modules/vscode-stats.ts
+++ b/modules/vscode-stats.ts
@@ -6,7 +6,7 @@ interface ExtensionStats {
   installs: number;
   rating: string;
   version: string;
-  repositoryUrl?: string;
+  relatedUrl?: string;
 }
 
 interface ExtensionData {
@@ -88,7 +88,7 @@ async function fetchExtensionStats(
     installs,
     rating: ratingText,
     version: extension.versions[0]?.version || "0.0.0",
-    repositoryUrl: config.repositoryUrl,
+    relatedUrl: config.relatedUrl,
   };
 }
 
@@ -112,8 +112,8 @@ export async function vscodeStats(): Promise<{
     "🚀 VSCode Extensions:\n" +
     stats
       .map((s) => {
-        const extensionName = s.repositoryUrl
-          ? `[${s.name}](${s.repositoryUrl})`
+        const extensionName = s.relatedUrl
+          ? `[${s.name}](${s.relatedUrl})`
           : s.name;
         return `- **${extensionName}**: ${s.installs.toLocaleString()} installs | ${s.rating
           } | v${s.version}`;


### PR DESCRIPTION
- config/packages.ts / config/extensions.ts のフィールド名を repositoryUrl から relatedUrl に変更
- modules/npm-stats.ts / modules/vscode-stats.ts の参照を relatedUrl に合わせて更新