### PR TITLE
Change npm download display to cumulative total

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 <!-- weather-greeting:start -->
-# 🌍 안녕하세요! 비가 오는 날이네요☔
-📍 Seoul: 16°C
+# 🌍 おはよう！雨ですね☔
+📍 Hiroshima: 14°C
 <!-- weather-greeting:end -->
 
 <!-- stats:start -->
-📦 **[pr-cannon](https://github.com/is0692vs/pr-cannon)**: 275 downloads/week
+📦 **[pr-cannon](https://github.com/is0692vs/pr-cannon)**: 641 total downloads
 
-![Download Stats](https://quickchart.io/chart?c=%7B%22type%22%3A%22line%22%2C%22data%22%3A%7B%22labels%22%3A%5B%222025-10-24%22%2C%222025-10-25%22%2C%222025-10-26%22%2C%222025-10-27%22%2C%222025-10-28%22%2C%222025-10-29%22%2C%222025-10-30%22%2C%222025-10-31%22%5D%2C%22datasets%22%3A%5B%7B%22label%22%3A%22pr-cannon%22%2C%22data%22%3A%5B366%2C366%2C589%2C601%2C613%2C634%2C636%2C275%5D%2C%22borderColor%22%3A%22%23FF6384%22%2C%22backgroundColor%22%3A%22transparent%22%2C%22tension%22%3A0.4%7D%5D%7D%2C%22options%22%3A%7B%22title%22%3A%7B%22display%22%3Atrue%2C%22text%22%3A%22npm%20Weekly%20Downloads%22%7D%2C%22scales%22%3A%7B%22yAxes%22%3A%5B%7B%22ticks%22%3A%7B%22beginAtZero%22%3Atrue%7D%7D%5D%7D%7D%7D&width=800&height=400)
+![Download Stats](https://quickchart.io/chart?c=%7B%22type%22%3A%22line%22%2C%22data%22%3A%7B%22labels%22%3A%5B%222025-10-24%22%2C%222025-10-25%22%2C%222025-10-26%22%2C%222025-10-27%22%2C%222025-10-28%22%2C%222025-10-29%22%2C%222025-10-30%22%2C%222025-10-31%22%5D%2C%22datasets%22%3A%5B%7B%22label%22%3A%22pr-cannon%22%2C%22data%22%3A%5B366%2C366%2C589%2C601%2C613%2C634%2C636%2C641%5D%2C%22borderColor%22%3A%22%23FF6384%22%2C%22backgroundColor%22%3A%22transparent%22%2C%22tension%22%3A0.4%7D%5D%7D%2C%22options%22%3A%7B%22title%22%3A%7B%22display%22%3Atrue%2C%22text%22%3A%22npm%20Weekly%20Downloads%22%7D%2C%22scales%22%3A%7B%22yAxes%22%3A%5B%7B%22ticks%22%3A%7B%22beginAtZero%22%3Atrue%7D%7D%5D%7D%7D%7D&width=800&height=400)
 <!-- stats:end -->
 
 <!-- vscode-stats:start -->
@@ -24,13 +24,13 @@
 ### 🤖 gemini2.5flashによる直近3日の活動サマリー
 
 直近3日間の活動サマリー:
-素晴らしい3日間でした！🎉 直近で**77件**ものコミットを重ね、多くの進捗がありましたね！
+直近3日間で、なんと77件ものコミットがありましたね！素晴らしい活動量です👏
 
-特に**link-canvas**では、VSCode拡張「Link Canvas」の基盤が大きく固まりました。WebviewベースのキャンバスUIが大幅に強化され、ズームやリサイズ、Monaco Editorの統合を実現。React Flowから独自のInfiniteCanvasへの移行も見事に完了し、より柔軟な操作性を手に入れましたね！🙌 VSCodeの標準APIとの連携も進み、エディタやMonaco Editor内でのコンテキストメニューから定義・参照を取得する機能が追加され、利便性が向上しました。Marketplace公開に向けたドキュメント整備やCI/CDの準備も着々と進んでいます。
+特に**`link-canvas`**リポジトリでは、WebviewベースのキャンバスUIが大きく進化しました！ズームやリサイズ、Monacoエディタの統合、さらにはReact Flowから独自のInfiniteCanvasへの移行など、機能の根幹部分を精力的に開発・改善されましたね。VSCodeのコンテキストメニューから定義や参照をキャンバスに表示する機能も実装され、実装ガイドやテスト手順の作成、マーケットプレイス公開に向けた準備まで着手されているのは驚きです🚀
 
-また、**code-mantra**では、アイドル状態検知機能と、コードの大量削除やファイルサイズ超過を通知するトリガー機能が追加されました。これらは開発の安全性と効率を高める重要な改善ですね！
+一方、**`code-mantra`**リポジリトでは、アイドル状態検知や大量削除、ファイルサイズ超過といった新しいトリガーと通知機能を実装し、開発体験向上に貢献されましたね。IdleManagerのデバウンス処理改善やテスト強化もバッチリです👍
 
-着実に素晴らしい成果を積み重ねています。この勢いで、次のステップも楽しみです！🚀
+これらの活発な開発は、プロジェクトの大きな前進に繋がっていますね！この調子で頑張ってください！✨
 
 _Total: 81 commits across 3 projects_
 

--- a/data/stats-history.json
+++ b/data/stats-history.json
@@ -44,7 +44,7 @@
   {
     "date": "2025-10-31",
     "packages": {
-      "pr-cannon": 275
+      "pr-cannon": 641
     }
   }
 ]


### PR DESCRIPTION
Update the npm download statistics to show total downloads instead of weekly downloads, enhancing clarity on package usage. Adjust related code to fetch and calculate total downloads accurately.